### PR TITLE
15 data validation

### DIFF
--- a/src/bblocks_data_importers/config.py
+++ b/src/bblocks_data_importers/config.py
@@ -49,8 +49,6 @@ class DataValidationError(Exception):
     """Raised when data validation fails."""
 
 
-
-
 def set_data_path(path):
     """Set the path to the folder containing the raw data or where raw data will be stored.
 

--- a/src/bblocks_data_importers/config.py
+++ b/src/bblocks_data_importers/config.py
@@ -45,6 +45,12 @@ class DataFormattingError(Exception):
     """Raised when data formatting fails."""
 
 
+class DataValidationError(Exception):
+    """Raised when data validation fails."""
+
+
+
+
 def set_data_path(path):
     """Set the path to the folder containing the raw data or where raw data will be stored.
 

--- a/src/bblocks_data_importers/data_validators.py
+++ b/src/bblocks_data_importers/data_validators.py
@@ -1,0 +1,47 @@
+"""Module for data validators."""
+
+import pandas as pd
+
+from bblocks_data_importers.config import logger, DataValidationError
+
+
+class DataFrameValidator:
+    """General validator for pandas DataFrame."""
+
+    def validate(self, df: pd.DataFrame, required_cols: list[str] = None) -> None:
+        """Validate the DataFrame."""
+
+        try:
+            self.check_empty_df(df)
+            if required_cols:
+                self.check_required_cols(df, required_cols)
+            self.check_pyarrow_dtypes(df)
+
+            logger.debug("DataFrame validation successful.")
+
+        except ValueError as e:
+            raise DataValidationError(f"Data validation failed. There may be an issue with the original data source or the data transformation process. Error: {e}")
+
+
+    @staticmethod
+    def check_empty_df(df: pd.DataFrame) -> None:
+        """Check if the DataFrame is empty. If it is raise an error."""
+
+        if df.empty:
+            raise ValueError("DataFrame is empty.")
+
+    @staticmethod
+    def check_required_cols(df: pd.DataFrame, required_cols: list[str]) -> None:
+        """Check if the DataFrame has the required columns. If not raise an error."""
+
+        missing_cols = [col for col in required_cols if col not in df.columns]
+        if missing_cols:
+            raise ValueError(f"Missing columns: {missing_cols}")
+
+    @staticmethod
+    def check_pyarrow_dtypes(df: pd.DataFrame) -> None:
+        """Check if the DataFrame has pyarrow-compatible dtypes. If not raise an error."""
+
+        for col in df.columns:
+            if not isinstance(df[col].dtype, pd.ArrowDtype):
+                raise ValueError(f"Column '{col}' does not have a pyarrow dtype.")

--- a/src/bblocks_data_importers/data_validators.py
+++ b/src/bblocks_data_importers/data_validators.py
@@ -20,8 +20,9 @@ class DataFrameValidator:
             logger.debug("DataFrame validation successful.")
 
         except ValueError as e:
-            raise DataValidationError(f"Data validation failed. There may be an issue with the original data source or the data transformation process. Error: {e}")
-
+            raise DataValidationError(
+                f"Data validation failed. There may be an issue with the original data source or the data transformation process. Error: {e}"
+            )
 
     @staticmethod
     def check_empty_df(df: pd.DataFrame) -> None:

--- a/src/bblocks_data_importers/imf/weo.py
+++ b/src/bblocks_data_importers/imf/weo.py
@@ -87,9 +87,10 @@ class WEO(DataImporter):
             version: version of the WEO data to load. If None, the latest version is loaded
         """
 
-        self._data[weo.fetch_data.last_version_fetched] = weo.fetch_data(version).pipe(
-            self._format_data
-        )
+        df = weo.fetch_data(version) # fetch the data
+        df = self._format_data(df) # format the data
+        # TODO: validate the data
+        self._data[weo.fetch_data.last_version_fetched] = df
 
         # if the latest version is loaded, save the version to _latest_version
         if version is None:

--- a/src/bblocks_data_importers/imf/weo.py
+++ b/src/bblocks_data_importers/imf/weo.py
@@ -30,6 +30,7 @@ from imf_reader import weo
 from bblocks_data_importers.protocols import DataImporter
 from bblocks_data_importers.utilities import convert_dtypes
 from bblocks_data_importers.config import logger, weo_version, Fields
+from bblocks_data_importers.data_validators import DataFrameValidator
 
 
 class WEO(DataImporter):
@@ -89,7 +90,7 @@ class WEO(DataImporter):
 
         df = weo.fetch_data(version) # fetch the data
         df = self._format_data(df) # format the data
-        # TODO: validate the data
+        DataFrameValidator().validate(df, required_cols=[Fields.value, Fields.year, Fields.entity_code, Fields.indicator_code]) # validate the data
         self._data[weo.fetch_data.last_version_fetched] = df
 
         # if the latest version is loaded, save the version to _latest_version

--- a/src/bblocks_data_importers/imf/weo.py
+++ b/src/bblocks_data_importers/imf/weo.py
@@ -88,9 +88,17 @@ class WEO(DataImporter):
             version: version of the WEO data to load. If None, the latest version is loaded
         """
 
-        df = weo.fetch_data(version) # fetch the data
-        df = self._format_data(df) # format the data
-        DataFrameValidator().validate(df, required_cols=[Fields.value, Fields.year, Fields.entity_code, Fields.indicator_code]) # validate the data
+        df = weo.fetch_data(version)  # fetch the data
+        df = self._format_data(df)  # format the data
+        DataFrameValidator().validate(
+            df,
+            required_cols=[
+                Fields.value,
+                Fields.year,
+                Fields.entity_code,
+                Fields.indicator_code,
+            ],
+        )  # validate the data
         self._data[weo.fetch_data.last_version_fetched] = df
 
         # if the latest version is loaded, save the version to _latest_version

--- a/src/bblocks_data_importers/who/ghed.py
+++ b/src/bblocks_data_importers/who/ghed.py
@@ -37,7 +37,7 @@ from bblocks_data_importers.config import (
     logger,
     DataExtractionError,
     DataFormattingError,
-    Fields
+    Fields,
 )
 from bblocks_data_importers.protocols import DataImporter
 from bblocks_data_importers.utilities import convert_dtypes
@@ -224,7 +224,17 @@ class GHED(DataImporter):
             self._raw_data = self._extract_raw_data()
 
         df = self._format_data()
-        DataFrameValidator().validate(df, required_cols=[Fields.country_name, Fields.iso3_code, Fields.year, Fields.indicator_code, Fields.indicator_name, Fields.value])
+        DataFrameValidator().validate(
+            df,
+            required_cols=[
+                Fields.country_name,
+                Fields.iso3_code,
+                Fields.year,
+                Fields.indicator_code,
+                Fields.indicator_name,
+                Fields.value,
+            ],
+        )
         self._data = df
         self._metadata = self._format_metadata()
         logger.info("Data imported successfully")

--- a/src/bblocks_data_importers/who/ghed.py
+++ b/src/bblocks_data_importers/who/ghed.py
@@ -37,9 +37,11 @@ from bblocks_data_importers.config import (
     logger,
     DataExtractionError,
     DataFormattingError,
+    Fields
 )
 from bblocks_data_importers.protocols import DataImporter
 from bblocks_data_importers.utilities import convert_dtypes
+from bblocks_data_importers.data_validators import DataFrameValidator
 
 URL: str = "https://apps.who.int/nha/database/Home/IndicatorsDownload/en"
 
@@ -134,7 +136,7 @@ class GHED(DataImporter):
             pd.read_excel(self._raw_data, sheet_name="Data", dtype_backend="pyarrow")
             .drop(columns=["region", "income"])
             .melt(id_vars=["country", "code", "year"], var_name="indicator_code")
-            .rename(columns={"country": "country_name", "code": "iso3_code"})
+            .rename(columns={"country": Fields.country_name, "code": Fields.iso3_code})
             .pipe(convert_dtypes)
         )
 
@@ -151,11 +153,11 @@ class GHED(DataImporter):
             )
             .rename(
                 columns={
-                    "variable code": "indicator_code",
-                    "variable name": "indicator_name",
+                    "variable code": Fields.indicator_code,
+                    "variable name": Fields.indicator_name,
                 }
             )
-            .loc[:, ["indicator_code", "indicator_name", "unit", "currency"]]
+            .loc[:, [Fields.indicator_code, Fields.indicator_name, "unit", "currency"]]
             .replace("-", np.nan)
             .pipe(convert_dtypes)
         )
@@ -187,10 +189,10 @@ class GHED(DataImporter):
         """
 
         cols = {
-            "country": "country_name",
-            "code": "iso3_code",
-            "variable name": "indicator_name",
-            "variable code": "indicator_code",
+            "country": Fields.country_name,
+            "code": Fields.iso3_code,
+            "variable name": Fields.indicator_name,
+            "variable code": Fields.indicator_code,
             "Sources": "sources",
             "Comments": "comments",
             "Data type": "data_type",
@@ -221,7 +223,9 @@ class GHED(DataImporter):
             logger.info("Importing data from GHED database")
             self._raw_data = self._extract_raw_data()
 
-        self._data = self._format_data()
+        df = self._format_data()
+        DataFrameValidator().validate(df, required_cols=[Fields.country_name, Fields.iso3_code, Fields.year, Fields.indicator_code, Fields.indicator_name, Fields.value])
+        self._data = df
         self._metadata = self._format_metadata()
         logger.info("Data imported successfully")
 

--- a/tests/test_who/test_ghed.py
+++ b/tests/test_who/test_ghed.py
@@ -296,36 +296,34 @@ def test_read_local_data_read_error(mock_open):
 
 
 @mock.patch("bblocks_data_importers.who.ghed.GHED._extract_raw_data")
-@mock.patch("bblocks_data_importers.who.ghed.GHED._format_data")
-@mock.patch("bblocks_data_importers.who.ghed.GHED._format_metadata")
-def test_load_data_no_local_file(
-    mock_format_metadata, mock_format_data, mock_extract_raw_data
-):
+def test_load_data_no_local_file(mock_extract_raw_data, mock_raw_data):
     """Test that _extract_raw_data is called when no local file is provided"""
 
-    mock_extract_raw_data.return_value = io.BytesIO(
-        b"some raw data"
-    )  # Mock the return value for _extract_raw_data
+    mock_extract_raw_data.return_value = mock_raw_data
+
     ghed = GHED()
     ghed._load_data()
 
     # Ensure that _extract_raw_data is called
     mock_extract_raw_data.assert_called_once()
 
-    # Ensure that the formatting methods are called
-    mock_format_data.assert_called_once()
-    mock_format_metadata.assert_called_once()
+
+@mock.patch("bblocks_data_importers.who.ghed.GHED._extract_raw_data")
+def test_load_data_invalid_data_format(mock_extract_raw_data):
+    """Check that the data validation fails when the data format is invalid"""
+
+    mock_extract_raw_data.return_value = io.BytesIO(b"invalid raw content")
+
+    ghed = GHED()
+    with pytest.raises(DataFormattingError):
+        ghed._load_data()
 
 
 @mock.patch("bblocks_data_importers.who.ghed.GHED._read_local_data")
-@mock.patch("bblocks_data_importers.who.ghed.GHED._format_data")
-@mock.patch("bblocks_data_importers.who.ghed.GHED._format_metadata")
-def test_load_data_with_local_file(
-    mock_format_metadata, mock_format_data, mock_read_local_data
-):
+def test_load_data_with_local_file(mock_read_local_data, mock_raw_data):
     """Test that _read_local_data is called when a local file is provided"""
-    # Mock the return value for _read_local_data
-    mock_read_local_data.return_value = io.BytesIO(b"some raw data")
+
+    mock_read_local_data.return_value = mock_raw_data
 
     # Initialize GHED with a local file
     ghed = GHED(data_file=TEST_FILE_PATH)
@@ -335,10 +333,6 @@ def test_load_data_with_local_file(
 
     # Ensure that _read_local_data is called
     mock_read_local_data.assert_called_once()
-
-    # Ensure that the formatting methods are called
-    mock_format_data.assert_called_once()
-    mock_format_metadata.assert_called_once()
 
 
 def test_clear_cache():


### PR DESCRIPTION
Adds a validation module
 Validation that can be applied to all importers is rather simple so using pydantic or pandera is overkill at the moment. The main things to test for is pyarrow types, empty dataframes, and required columns 

- minor bug fix of weo module
- add validation to weo and ghed module
- update ghed tests


Closes #15 