### PR TITLE
38 hdi importer

### DIFF
--- a/docs/Importers/hdi.ipynb
+++ b/docs/Importers/hdi.ipynb
@@ -1,0 +1,349 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "# Human Development Index (HDI) Data Importer",
+   "id": "785d0f3879888104"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "The `HumanDevelopmentIndex` class is used to access data for the Human Development Index (HDI)",
+   "id": "fd9cb232216e7eab"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "### Basic Usage",
+   "id": "91d616c229cb2db7"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-05T14:02:52.246366Z",
+     "start_time": "2025-04-05T14:02:51.842773Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "from bblocks_data_importers import HumanDevelopmentIndex",
+   "id": "9947fbde2e788f73",
+   "outputs": [],
+   "execution_count": 3
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-05T14:03:08.340817Z",
+     "start_time": "2025-04-05T14:03:08.336047Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "hdi = HumanDevelopmentIndex()",
+   "id": "f1d59e20a80c9bc5",
+   "outputs": [],
+   "execution_count": 4
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Get the latest data",
+   "id": "c9a7a18925bb610c"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-05T14:03:50.318419Z",
+     "start_time": "2025-04-05T14:03:49.641066Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "df = hdi.get_data()\n",
+    "df.head()"
+   ],
+   "id": "e33cd76664880e25",
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: Extracting HDI data\n",
+      "INFO: Extracting HDI metadata\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "  entity_code  entity_name region_code  hdi_group indicator_code  value  year  \\\n",
+       "0         AFG  Afghanistan          SA        Low       hdi_rank  182.0  2022   \n",
+       "1         ALB      Albania         ECA       High       hdi_rank   74.0  2022   \n",
+       "2         DZA      Algeria          AS       High       hdi_rank   93.0  2022   \n",
+       "3         AND      Andorra        <NA>  Very High       hdi_rank   35.0  2022   \n",
+       "4         AGO       Angola         SSA     Medium       hdi_rank  150.0  2022   \n",
+       "\n",
+       "  indicator_name  \n",
+       "0       HDI Rank  \n",
+       "1       HDI Rank  \n",
+       "2       HDI Rank  \n",
+       "3       HDI Rank  \n",
+       "4       HDI Rank  "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entity_code</th>\n",
+       "      <th>entity_name</th>\n",
+       "      <th>region_code</th>\n",
+       "      <th>hdi_group</th>\n",
+       "      <th>indicator_code</th>\n",
+       "      <th>value</th>\n",
+       "      <th>year</th>\n",
+       "      <th>indicator_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AFG</td>\n",
+       "      <td>Afghanistan</td>\n",
+       "      <td>SA</td>\n",
+       "      <td>Low</td>\n",
+       "      <td>hdi_rank</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>HDI Rank</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ALB</td>\n",
+       "      <td>Albania</td>\n",
+       "      <td>ECA</td>\n",
+       "      <td>High</td>\n",
+       "      <td>hdi_rank</td>\n",
+       "      <td>74.0</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>HDI Rank</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>DZA</td>\n",
+       "      <td>Algeria</td>\n",
+       "      <td>AS</td>\n",
+       "      <td>High</td>\n",
+       "      <td>hdi_rank</td>\n",
+       "      <td>93.0</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>HDI Rank</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>AND</td>\n",
+       "      <td>Andorra</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>Very High</td>\n",
+       "      <td>hdi_rank</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>HDI Rank</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>AGO</td>\n",
+       "      <td>Angola</td>\n",
+       "      <td>SSA</td>\n",
+       "      <td>Medium</td>\n",
+       "      <td>hdi_rank</td>\n",
+       "      <td>150.0</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>HDI Rank</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 5
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Get the metadata",
+   "id": "6f1239ef191a88c4"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-05T14:04:15.153399Z",
+     "start_time": "2025-04-05T14:04:15.144627Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "meta_df = hdi.get_metadata()\n",
+    "meta_df.head()"
+   ],
+   "id": "54245bb78d857115",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "             indicator_name indicator_code time_range notes\n",
+       "0                      ISO3           iso3          -  <NA>\n",
+       "1          HDR Country Name        country          -  <NA>\n",
+       "2  Human Development Groups        hdicode          -  <NA>\n",
+       "3  UNDP Developeing Regions         region          -  <NA>\n",
+       "5                  HDI Rank       hdi_rank       2022  <NA>"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>indicator_name</th>\n",
+       "      <th>indicator_code</th>\n",
+       "      <th>time_range</th>\n",
+       "      <th>notes</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>ISO3</td>\n",
+       "      <td>iso3</td>\n",
+       "      <td>-</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>HDR Country Name</td>\n",
+       "      <td>country</td>\n",
+       "      <td>-</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Human Development Groups</td>\n",
+       "      <td>hdicode</td>\n",
+       "      <td>-</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>UNDP Developeing Regions</td>\n",
+       "      <td>region</td>\n",
+       "      <td>-</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>HDI Rank</td>\n",
+       "      <td>hdi_rank</td>\n",
+       "      <td>2022</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 7
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Clear the cache",
+   "id": "312de420d897a06b"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-05T14:04:43.932888Z",
+     "start_time": "2025-04-05T14:04:43.926956Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "hdi.clear_cache()",
+   "id": "5a1ac1e77d4922e0",
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: Cache cleared\n"
+     ]
+    }
+   ],
+   "execution_count": 8
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "53bda968f9dd0ea2"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/Importers/index.md
+++ b/docs/Importers/index.md
@@ -10,4 +10,5 @@ ghed.ipynb
 wfp.ipynb
 world_bank.ipynb
 international_debt_statistics.ipynb
+hdi.ipynb
 ```

--- a/src/bblocks_data_importers/__init__.py
+++ b/src/bblocks_data_importers/__init__.py
@@ -6,5 +6,6 @@ from bblocks_data_importers.imf.weo import WEO
 from bblocks_data_importers.wfp.wfp import WFPFoodSecurity, WFPInflation
 from bblocks_data_importers.world_bank.wb_api import WorldBank
 from bblocks_data_importers.world_bank.ids import InternationalDebtStatistics
+from bblocks_data_importers.undp.hdi import HumanDevelopmentIndex
 
 __version__ = version("bblocks_data_importers")

--- a/src/bblocks_data_importers/config.py
+++ b/src/bblocks_data_importers/config.py
@@ -96,6 +96,8 @@ class Fields:
     currency = "currency"
     source = "source"
     data_type = "data_type"
+    time_range = "time_range"
+    notes = "notes"
 
     @classmethod
     def get_base_idx(cls):

--- a/src/bblocks_data_importers/config.py
+++ b/src/bblocks_data_importers/config.py
@@ -73,17 +73,16 @@ class Fields:
     value_upper = "value_upper"
     value_lower = "value_lower"
 
-    # country, region and other entity names
+    # country, region and other entity names and codes
     country_name = "country_name"
     region_name = "region_name"
-    entity_name = "entity_name"
-
-    # country, region and other entity codes
+    entity_name = "entity_name" # The name of the entity (country or region) to be used when entities are mixed
     iso2_code = "iso2_code"
     iso3_code = "iso3_code"
     entity_code = "entity_code"
     counterpart_code = "counterpart_code"
     counterpart_name = "counterpart_name"
+    region_code = "region_code"
 
     # time fields
     year = "year"

--- a/src/bblocks_data_importers/config.py
+++ b/src/bblocks_data_importers/config.py
@@ -76,7 +76,7 @@ class Fields:
     # country, region and other entity names and codes
     country_name = "country_name"
     region_name = "region_name"
-    entity_name = "entity_name" # The name of the entity (country or region) to be used when entities are mixed
+    entity_name = "entity_name"  # The name of the entity (country or region) to be used when entities are mixed
     iso2_code = "iso2_code"
     iso3_code = "iso3_code"
     entity_code = "entity_code"

--- a/src/bblocks_data_importers/undp/hdi.py
+++ b/src/bblocks_data_importers/undp/hdi.py
@@ -1,0 +1,2 @@
+"""Human Development Index (HDI) data importer."""
+

--- a/src/bblocks_data_importers/undp/hdi.py
+++ b/src/bblocks_data_importers/undp/hdi.py
@@ -3,8 +3,10 @@
 import pandas as pd
 import requests
 import io
+import numpy as np
 
 from bblocks_data_importers.config import logger, DataExtractionError, Fields
+from bblocks_data_importers.protocols import DataImporter
 
 
 DATA_URL = "https://hdr.undp.org/sites/default/files/2023-24_HDR/HDR23-24_Composite_indices_complete_time_series.csv"
@@ -81,4 +83,85 @@ def clean_metadata(metadata_df: pd.DataFrame) -> pd.DataFrame:
                         })
      )
 
+
+
+def clean_data(data_df: pd.DataFrame, metadata_df: pd.DataFrame) -> pd.DataFrame:
+    """ Clean the HDI data DataFrame.
+
+    Args:
+        data_df (pd.DataFrame): The HDI data DataFrame.
+        metadata_df (pd.DataFrame): The HDI metadata DataFrame.
+
+    Returns:
+        The cleaned HDI data DataFrame.
+    """
+
+    return (data_df
+            .rename(columns = {'iso3': Fields.entity_code, "country": Fields.entity_name, "region": Fields.region_code})
+            .melt(id_vars = [Fields.entity_code, Fields.entity_name, Fields.region_code], var_name = Fields.indicator_code, value_name = Fields.value)
+            .assign(split=lambda d: d.indicator_code.apply(lambda x: x.rsplit('_', 1) if '_' in x else [x, np.nan]))
+            .assign(indicator_code=lambda x: x['split'].str[0], year=lambda x: x['split'].str[1])
+            .drop(columns=['split'])
+            .assign(indicator_name= lambda d: d.indicator_code.map(metadata_df.set_index("indicator_code")['indicator_name'].to_dict()))
+            )
+
+
+class HumanDevelopmentIndex(DataImporter):
+    """A class to import Human Development Index (HDI) data from UNDP."""
+
+    def __init__(self, *, timeout: int = 30):
+        self._timeout = timeout
+        self._data_df: pd.DataFrame | None = None
+        self._metadata_df: pd.DataFrame | None = None
+
+
+    def _extract_metadata(self):
+        """Extract HDI metadata from the source."""
+
+        logger.info("Extracting HDI metadata")
+
+        metadata_df = read_hdi_metadata(timeout=self._timeout)
+        self._metadata_df = clean_metadata(metadata_df)
+
+    def _extract_data(self) -> None:
+        """Extract HDI data from the source."""
+
+        logger.info("Extracting HDI data")
+
+        df = read_hdi_data(timeout=self._timeout)
+        if self._metadata_df is None:
+            self._extract_metadata()
+
+        self._data_df = clean_data(df, self._metadata_df)
+
+
+    def get_metadata(self) -> pd.DataFrame:
+        """Get the HDI metadata
+
+        Returns:
+            The HDI metadata DataFrame.
+        """
+
+        if self._metadata_df is None:
+            self._extract_metadata()
+        return self._metadata_df
+
+    def get_data(self) -> pd.DataFrame:
+        """Get the HDI data
+
+        Returns:
+            The HDI data DataFrame.
+        """
+
+        if self._data_df is None:
+            self._extract_data()
+        return self._data_df
+
+    def clear_cache(self) -> None:
+        """Clear the cached data and metadata."""
+
+        self._data_df = None
+        self._metadata_df = None
+
+        logger.info("Cache cleared")
 

--- a/src/bblocks_data_importers/undp/hdi.py
+++ b/src/bblocks_data_importers/undp/hdi.py
@@ -1,4 +1,7 @@
-"""Human Development Index (HDI) data importer."""
+"""Human Development Index (HDI) data importer.
+
+
+"""
 
 import pandas as pd
 import requests
@@ -127,9 +130,10 @@ class HumanDevelopmentIndex(DataImporter):
         logger.info("Extracting HDI metadata")
 
         metadata_df = read_hdi_metadata(timeout=self._timeout)
+        metadata_df = clean_metadata(metadata_df)
 
-        # DataFrameValidator().validate(metadata_df, ['indicator_name', 'indicator_code'])
-        self._metadata_df = clean_metadata(metadata_df)
+        DataFrameValidator().validate(metadata_df, ['indicator_name', 'indicator_code'])
+        self._metadata_df = metadata_df
 
     def _extract_data(self) -> None:
         """Extract HDI data from the source."""
@@ -140,9 +144,11 @@ class HumanDevelopmentIndex(DataImporter):
         if self._metadata_df is None:
             self._extract_metadata()
 
-        # DataFrameValidator().validate(df, ['indicator_code', 'indicator_name', 'year', 'value', 'entity_code', 'entity_name'])
+        df = clean_data(df, self._metadata_df)
 
-        self._data_df = clean_data(df, self._metadata_df)
+        DataFrameValidator().validate(df, ['indicator_code', 'indicator_name', 'year', 'value', 'entity_code', 'entity_name'])
+
+        self._data_df = df
 
 
     def get_metadata(self) -> pd.DataFrame:

--- a/src/bblocks_data_importers/undp/hdi.py
+++ b/src/bblocks_data_importers/undp/hdi.py
@@ -1,2 +1,62 @@
 """Human Development Index (HDI) data importer."""
 
+import pandas as pd
+import requests
+import io
+
+from bblocks_data_importers.config import logger, DataExtractionError
+
+
+DATA_URL = "https://hdr.undp.org/sites/default/files/2023-24_HDR/HDR23-24_Composite_indices_complete_time_series.csv"
+METADATA_URL = "https://hdr.undp.org/sites/default/files/2023-24_HDR/HDR23-24_Composite_indices_metadata.xlsx"
+DATA_ENCODING = "latin1" # Encoding used by the HDI data
+
+def _request_hdi_data(url, *, timeout: int) -> requests.Response:
+    """ Request the HDI data from the URL.
+
+    Args:
+        url (str): URL to request the HDI data from.
+        timeout (int): Timeout for the request in seconds
+
+    Returns:
+        Response object containing the HDI data.
+    """
+
+    logger.debug("Requesting HDI data")
+
+    try:
+
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+        return response
+
+    except requests.RequestException as e:
+        raise DataExtractionError(f"Error requesting HDI data: {e}") from e
+
+
+def read_hdi_data(*, encoding = DATA_ENCODING, timeout: int = 30) -> pd.DataFrame:
+    """ Read the HDI data from the response."""
+
+    logger.debug("Reading HDI data")
+
+    try:
+        response = _request_hdi_data(DATA_URL, timeout=timeout)
+        data = pd.read_csv(io.BytesIO(response.content), encoding=encoding)
+        return data
+
+    except pd.errors.ParserError as e:
+        raise DataExtractionError(f"Error reading HDI data: {e}") from e
+
+
+def read_hdi_metadata(*, timeout: int=30) -> pd.DataFrame:
+    """ Read the HDI metadata from the response."""
+
+    logger.debug("Reading HDI metadata")
+
+    try:
+        response = _request_hdi_data(METADATA_URL, timeout=timeout)
+        metadata = pd.read_excel(io.BytesIO(response.content))
+        return metadata
+
+    except pd.errors.ParserError as e:
+        raise DataExtractionError(f"Error reading HDI metadata: {e}") from e

--- a/src/bblocks_data_importers/undp/hdi.py
+++ b/src/bblocks_data_importers/undp/hdi.py
@@ -4,7 +4,7 @@ import pandas as pd
 import requests
 import io
 
-from bblocks_data_importers.config import logger, DataExtractionError
+from bblocks_data_importers.config import logger, DataExtractionError, Fields
 
 
 DATA_URL = "https://hdr.undp.org/sites/default/files/2023-24_HDR/HDR23-24_Composite_indices_complete_time_series.csv"
@@ -60,3 +60,25 @@ def read_hdi_metadata(*, timeout: int=30) -> pd.DataFrame:
 
     except pd.errors.ParserError as e:
         raise DataExtractionError(f"Error reading HDI metadata: {e}") from e
+
+
+def clean_metadata(metadata_df: pd.DataFrame) -> pd.DataFrame:
+    """ Clean the HDI metadata DataFrame.
+
+    Args:
+        metadata_df (pd.DataFrame): The HDI metadata DataFrame.
+
+    Returns:
+        The cleaned HDI metadata DataFrame.
+    """
+
+    return (metadata_df
+     .dropna(subset="Time series")
+     .rename(columns = {'Full name': Fields.indicator_name,
+                        "Short name": Fields.indicator_code,
+                        "Time series": Fields.time_range,
+                        "Note": Fields.notes
+                        })
+     )
+
+

--- a/tests/test_undp/test_hdi.py
+++ b/tests/test_undp/test_hdi.py
@@ -1,0 +1,344 @@
+"""Unit tests for the HumanDevelopmentIndex importer
+"""
+
+import pytest
+from unittest import mock
+import pandas as pd
+import numpy as np
+from io import BytesIO
+
+from bblocks_data_importers.undp import hdi
+from bblocks_data_importers.config import Fields, DataExtractionError
+
+
+# ------------------------------------------------------------------------------
+# FIXTURES
+# ------------------------------------------------------------------------------
+@pytest.fixture
+def mock_hdi_csv_content():
+    """
+    Mock CSV content for HDI data.
+    This CSV fixture includes a small snippet of columns that represent the
+    structure of your HDI data: iso3, country, region, hdicode, indicator_year pairs.
+    """
+    csv_str = (
+        "iso3,country,region,hdicode,HDI_2000,HDI_2001,INEQUALITY_INDEX_2000\n"
+        "ABC,Testland,TestRegion,High,0.500,0.505,0.1\n"
+        "XYZ,Mockland,MockRegion,Low,0.300,0.305,0.2\n"
+    )
+    return csv_str.encode(hdi.DATA_ENCODING)
+
+
+@pytest.fixture
+def mock_hdi_metadata_content():
+    """
+    Mock Excel content for HDI metadata.
+    Typically includes columns like 'Full name', 'Short name', 'Time series', 'Note'.
+    """
+    metadata_df = pd.DataFrame({
+        "Full name": ["Human Development Index", "Inequality Index"],
+        "Short name": ["HDI", "INEQUALITY_INDEX"],
+        "Time series": ["1990-2023", "1990-2023"],
+        "Note": ["Composite index of life, ed, GNI", "Measures inequality dimension"]
+    })
+
+    excel_buffer = BytesIO()
+    with pd.ExcelWriter(excel_buffer, engine="xlsxwriter") as writer:
+        metadata_df.to_excel(writer, index=False)
+    return excel_buffer.getvalue()
+
+
+@pytest.fixture
+def mock_hdi_df():
+    """A pandas DataFrame that simulates the raw HDI data *before* cleaning."""
+    return pd.DataFrame({
+        "iso3": ["ABC", "XYZ"],
+        "country": ["Testland", "Mockland"],
+        "region": ["TestRegion", "MockRegion"],
+        "hdicode": ["High", "Low"],
+        "HDI_2000": [0.5, 0.3],
+        "HDI_2001": [0.505, 0.305],
+        "INEQUALITY_INDEX_2000": [0.1, 0.2],
+    })
+
+
+@pytest.fixture
+def mock_metadata_df():
+    """A pandas DataFrame that simulates the metadata *before* cleaning."""
+    return pd.DataFrame({
+        "Full name": ["Human Development Index", "Inequality Index"],
+        "Short name": ["HDI", "INEQUALITY_INDEX"],
+        "Time series": ["1990-2023", "1990-2023"],
+        "Note": ["Composite index of life, ed, GNI", "Measures inequality dimension"]
+    })
+
+
+# ------------------------------------------------------------------------------
+# TESTS FOR LOWER-LEVEL FUNCTIONS
+# ------------------------------------------------------------------------------
+def test_request_hdi_data_success(mock_hdi_csv_content):
+    """hdi._request_hdi_data should return a valid response when requests.get succeeds."""
+    with mock.patch("requests.get") as mock_get:
+        mock_response = mock.Mock()
+        mock_response.content = mock_hdi_csv_content
+        mock_response.raise_for_status = mock.Mock()
+        mock_get.return_value = mock_response
+
+        response = hdi._request_hdi_data(hdi.DATA_URL, timeout=5)
+        mock_get.assert_called_once_with(hdi.DATA_URL, timeout=5)
+        assert response.content == mock_hdi_csv_content
+        mock_response.raise_for_status.assert_called_once()
+
+
+def test_request_hdi_data_failure():
+    """hdi._request_hdi_data should raise DataExtractionError when requests.get fails."""
+    with mock.patch("requests.get", side_effect=Exception("Network error")):
+        with pytest.raises(DataExtractionError, match="Error requesting HDI data: Network error"):
+            hdi._request_hdi_data(hdi.DATA_URL, timeout=5)
+
+
+def test_read_hdi_data_success(mock_hdi_csv_content):
+    """
+    hdi.read_hdi_data should return a DataFrame with correct shape/columns
+    when it successfully reads CSV data.
+    """
+    with mock.patch("bblocks_data_importers.undp.hdi._request_hdi_data") as mock_request:
+        mock_response = mock.Mock()
+        mock_response.content = mock_hdi_csv_content
+        mock_request.return_value = mock_response
+
+        df = hdi.read_hdi_data(encoding=hdi.DATA_ENCODING, timeout=5)
+
+        assert isinstance(df, pd.DataFrame)
+        # 2 rows, 7 columns
+        assert df.shape == (2, 7)
+        expected_cols = ["iso3", "country", "region", "hdicode", "HDI_2000", "HDI_2001", "INEQUALITY_INDEX_2000"]
+        for col in expected_cols:
+            assert col in df.columns
+
+
+def test_read_hdi_data_parser_error():
+    # 1) Create a mock response object with actual bytes for content
+    mock_response = mock.Mock()
+    mock_response.content = b"some raw CSV bytes"
+
+    # 2) Patch _request_hdi_data so it returns this mock response
+    with mock.patch(
+            "bblocks_data_importers.undp.hdi._request_hdi_data",
+            return_value=mock_response
+    ):
+        # 3) Force pandas.read_csv to raise a ParserError
+        with mock.patch("pandas.read_csv", side_effect=pd.errors.ParserError("Invalid CSV")):
+            # 4) Now your code attempts read_csv -> hits the mock side_effect -> raises
+            with pytest.raises(DataExtractionError, match="Error reading HDI data:"):
+                hdi.read_hdi_data()
+
+
+def test_read_hdi_metadata_success(mock_hdi_metadata_content):
+    """hdi.read_hdi_metadata should return a DataFrame with correct shape/columns on success."""
+    with mock.patch("bblocks_data_importers.undp.hdi._request_hdi_data") as mock_request:
+        mock_response = mock.Mock()
+        mock_response.content = mock_hdi_metadata_content
+        mock_request.return_value = mock_response
+
+        meta_df = hdi.read_hdi_metadata(timeout=5)
+        assert isinstance(meta_df, pd.DataFrame)
+        # 2 rows, 4 columns
+        assert meta_df.shape == (2, 4)
+        assert "Full name" in meta_df.columns
+        assert "Short name" in meta_df.columns
+        assert "Time series" in meta_df.columns
+        assert "Note" in meta_df.columns
+
+
+def test_read_hdi_metadata_parser_error():
+    """If the Excel is malformed, hdi.read_hdi_metadata should raise DataExtractionError."""
+    with mock.patch("bblocks_data_importers.undp.hdi._request_hdi_data") as mock_request:
+        mock_response = mock.Mock()
+        mock_response.content = b"NOT_AN_EXCEL_FILE"
+        mock_request.return_value = mock_response
+
+        with pytest.raises(DataExtractionError, match="Error reading HDI metadata:"):
+            hdi.read_hdi_metadata()
+
+
+def test_clean_metadata(mock_metadata_df):
+    """
+    Test that hdi.clean_metadata:
+    - drops rows with no 'Time series'
+    - renames columns to the Fields
+    - converts dtypes to pyarrow
+    """
+    # Add a row with NaN "Time series" to see if it's dropped
+    mock_metadata_df.loc[len(mock_metadata_df)] = ["Extra", "EXTRA_CODE", np.nan, "No time series here"]
+
+    cleaned = hdi.clean_metadata(mock_metadata_df)
+    # One row should be dropped => we get 2 original rows left
+    assert cleaned.shape[0] == 2, "Rows with NaN in 'Time series' should be dropped."
+
+    for col in [Fields.indicator_name, Fields.indicator_code, Fields.time_range, Fields.notes]:
+        assert col in cleaned.columns, f"{col} not found in cleaned metadata columns."
+
+    # Ensure arrow dtypes
+    for dtype in cleaned.dtypes:
+        assert isinstance(dtype, pd.ArrowDtype), "Columns are not pyarrow dtypes in cleaned metadata."
+
+
+def test_clean_data(mock_hdi_df, mock_metadata_df):
+    """
+    Test that hdi.clean_data:
+    - melts from wide to long,
+    - extracts 'year' from the column suffix,
+    - maps indicator_code -> indicator_name from metadata,
+    - converts columns to arrow dtypes.
+    """
+    meta_cleaned = hdi.clean_metadata(mock_metadata_df)
+
+    cleaned_df = hdi.clean_data(mock_hdi_df, meta_cleaned)
+
+    # We have 3 indicator columns: HDI_2000, HDI_2001, INEQUALITY_INDEX_2000
+    # For 2 rows => 6 rows after melt
+    assert cleaned_df.shape[0] == 6, "Melted rows don't match expected count."
+
+    required_cols = [
+        Fields.entity_code,
+        Fields.entity_name,
+        Fields.region_code,
+        Fields.indicator_code,
+        Fields.value,
+        Fields.indicator_name,
+        Fields.year,
+    ]
+    for col in required_cols:
+        assert col in cleaned_df.columns, f"{col} missing in cleaned data."
+
+    # Check year extraction
+    unique_years = sorted(cleaned_df[Fields.year].dropna().unique().tolist())
+    # [2000, 2001]
+    assert unique_years == [2000, 2001], "Years not extracted correctly."
+
+    # Check indicator_code & indicator_name were mapped correctly
+    unique_codes = cleaned_df[Fields.indicator_code].unique().tolist()
+    assert "HDI" in unique_codes
+    assert "INEQUALITY_INDEX" in unique_codes
+
+    # Check arrow dtypes
+    for dtype in cleaned_df.dtypes:
+        assert isinstance(dtype, pd.ArrowDtype), "DataFrame columns are not pyarrow dtypes."
+
+
+# ------------------------------------------------------------------------------
+# TESTS FOR HumanDevelopmentIndex CLASS
+# ------------------------------------------------------------------------------
+@pytest.fixture
+def mock_read_hdi_data_func(mock_hdi_df):
+    """Mocks hdi.read_hdi_data to return mock_hdi_df."""
+    with mock.patch("bblocks_data_importers.undp.hdi.read_hdi_data", return_value=mock_hdi_df):
+        yield
+
+
+@pytest.fixture
+def mock_read_hdi_metadata_func(mock_metadata_df):
+    """Mocks hdi.read_hdi_metadata to return mock_metadata_df."""
+    with mock.patch("bblocks_data_importers.undp.hdi.read_hdi_metadata", return_value=mock_metadata_df):
+        yield
+
+
+def test_hdi_init():
+    """Test initial state of hdi.HumanDevelopmentIndex class."""
+    hdi_importer = hdi.HumanDevelopmentIndex()
+    assert hdi_importer._data_df is None, "Data should not be loaded at init."
+    assert hdi_importer._metadata_df is None, "Metadata should not be loaded at init."
+
+
+def test_extract_metadata(mock_read_hdi_metadata_func):
+    """Test hdi.HumanDevelopmentIndex._extract_metadata loads and cleans metadata."""
+    hdi_importer = hdi.HumanDevelopmentIndex()
+    hdi_importer._extract_metadata()
+
+    assert hdi_importer._metadata_df is not None, "Metadata DataFrame should be set after _extract_metadata()."
+    assert Fields.indicator_name in hdi_importer._metadata_df.columns, (
+        "Expected column from cleaned metadata not found."
+    )
+
+
+def test_extract_data(mock_read_hdi_data_func, mock_read_hdi_metadata_func):
+    """
+    Test hdi.HumanDevelopmentIndex._extract_data loads data and metadata (if not already present),
+    cleans it, and populates _data_df.
+    """
+    hdi_importer = hdi.HumanDevelopmentIndex()
+    hdi_importer._extract_data()
+
+    assert hdi_importer._data_df is not None, "Data DataFrame should be set after _extract_data()."
+    assert hdi_importer._metadata_df is not None, "Metadata should also be loaded."
+    assert Fields.entity_code in hdi_importer._data_df.columns, (
+        "Cleaned data missing expected columns."
+    )
+
+
+def test_get_metadata_cached(mock_read_hdi_metadata_func):
+    """
+    Test hdi.HumanDevelopmentIndex.get_metadata when metadata is already cached.
+    Should return the cached version, not re-fetch.
+    """
+    hdi_importer = hdi.HumanDevelopmentIndex()
+    cached_meta = pd.DataFrame({"test_col": [1, 2, 3]})
+    hdi_importer._metadata_df = cached_meta
+
+    meta = hdi_importer.get_metadata()
+    assert meta.equals(cached_meta), "get_metadata did not return the cached metadata."
+
+
+def test_get_metadata_not_cached(mock_read_hdi_metadata_func):
+    """
+    Test hdi.HumanDevelopmentIndex.get_metadata when metadata is not cached,
+    so the method should call _extract_metadata.
+    """
+    hdi_importer = hdi.HumanDevelopmentIndex()
+    meta = hdi_importer.get_metadata()
+
+    assert hdi_importer._metadata_df is not None, "Metadata was not loaded."
+    assert isinstance(meta, pd.DataFrame), "Expected a DataFrame from get_metadata."
+
+
+def test_get_data_cached(mock_read_hdi_data_func, mock_read_hdi_metadata_func):
+    """
+    Test hdi.HumanDevelopmentIndex.get_data when data is already cached.
+    Should just return the cached data, not re-fetch.
+    """
+    hdi_importer = hdi.HumanDevelopmentIndex()
+    cached_data = pd.DataFrame({"test_col": [10, 20, 30]})
+    hdi_importer._data_df = cached_data
+
+    data = hdi_importer.get_data()
+    assert data.equals(cached_data), "get_data did not return the cached data."
+
+
+def test_get_data_not_cached(mock_read_hdi_data_func, mock_read_hdi_metadata_func):
+    """
+    Test hdi.HumanDevelopmentIndex.get_data when data is not cached,
+    so it should call _extract_data.
+    """
+    hdi_importer = hdi.HumanDevelopmentIndex()
+    data = hdi_importer.get_data()
+
+    assert hdi_importer._data_df is not None, "Data was not loaded."
+    assert isinstance(data, pd.DataFrame), "Expected a DataFrame from get_data."
+    # Confirm metadata also gets loaded
+    assert hdi_importer._metadata_df is not None, "Metadata should also be loaded by get_data."
+
+
+def test_clear_cache(mock_read_hdi_data_func, mock_read_hdi_metadata_func):
+    """
+    Test hdi.HumanDevelopmentIndex.clear_cache resets both _data_df and _metadata_df to None.
+    """
+    hdi_importer = hdi.HumanDevelopmentIndex()
+    # Load data so _data_df and _metadata_df are populated
+    hdi_importer.get_data()
+    assert hdi_importer._data_df is not None
+    assert hdi_importer._metadata_df is not None
+
+    hdi_importer.clear_cache()
+    assert hdi_importer._data_df is None, "_data_df should be None after clearing cache."
+    assert hdi_importer._metadata_df is None, "_metadata_df should be None after clearing cache."


### PR DESCRIPTION
Create an importer for HDI data
Update documentation
___ 

This pull request introduces a new data importer for the Human Development Index (HDI) and includes several related changes to the codebase and documentation. The most important changes are the addition of the `HumanDevelopmentIndex` class, updates to the `Fields` class, and documentation updates.

### New HDI Data Importer:

* [`src/bblocks_data_importers/undp/hdi.py`](diffhunk://#diff-d0e10dab1974d57d84fd9bcabb74602064563e56a07e1625136c4610840b5b89R1-R289): Added the `HumanDevelopmentIndex` class to import HDI data, including methods for extracting, cleaning, and caching the data and metadata.

### Updates to Fields Class:

* [`src/bblocks_data_importers/config.py`](diffhunk://#diff-883562a00adfa10f138fc7339262db27c55864588851972fe89b3c4f3f601eb7L76-R85): Updated the `Fields` class to include new fields `region_code`, `time_range`, and `notes`, and added comments for clarity. [[1]](diffhunk://#diff-883562a00adfa10f138fc7339262db27c55864588851972fe89b3c4f3f601eb7L76-R85) [[2]](diffhunk://#diff-883562a00adfa10f138fc7339262db27c55864588851972fe89b3c4f3f601eb7R98-R99)

### Documentation Updates:

* [`docs/Importers/hdi.ipynb`](diffhunk://#diff-0e7054bdd62d02bbc633cd934f4b7efc54aa612e837fc7962d359bfe90ce9063R1-R349): Added a new Jupyter notebook demonstrating the usage of the `HumanDevelopmentIndex` class, including examples of getting data and metadata, and clearing the cache.
* [`docs/Importers/index.md`](diffhunk://#diff-a24c14e9f276fac973b5a438c7607ce59d609a567b2ffbe35180d49e1b723468R13): Updated the index to include a link to the new `hdi.ipynb` notebook.

### Initialization Update:

* [`src/bblocks_data_importers/__init__.py`](diffhunk://#diff-e17c3e4ae9bc027ac0e521b2e86cc108de3ec68b2504d3fb6d7758d215577628R9): Added the `HumanDevelopmentIndex` import to the package initializer.